### PR TITLE
Add dummy pdelay_resp_fup option

### DIFF
--- a/config.c
+++ b/config.c
@@ -369,6 +369,7 @@ struct config_item config_tab[] = {
 	GLOB_ITEM_INT("egress_vlan.tagged", 0, 0, 1),
 	GLOB_ITEM_INT("egress_vlan.id", 0, 0, 4095),
 	GLOB_ITEM_INT("egress_vlan.prio", 0, 0, 7),
+	PORT_ITEM_INT("dummy_pdelay_resp_fup", 0, 0, 1),
 };
 
 static struct unicast_master_table *current_uc_mtab;

--- a/config.c
+++ b/config.c
@@ -370,6 +370,7 @@ struct config_item config_tab[] = {
 	GLOB_ITEM_INT("egress_vlan.id", 0, 0, 4095),
 	GLOB_ITEM_INT("egress_vlan.prio", 0, 0, 7),
 	PORT_ITEM_INT("dummy_pdelay_resp_fup", 0, 0, 1),
+	PORT_ITEM_INT("ptp_header_offset", 0, 0, INT_MAX),
 };
 
 static struct unicast_master_table *current_uc_mtab;

--- a/net_tstamp_cpy.h
+++ b/net_tstamp_cpy.h
@@ -70,6 +70,11 @@ struct so_timestamping {
  * @tx_type:	one of HWTSTAMP_TX_*
  * @rx_filter:	one of HWTSTAMP_FILTER_*
  * @clk_type    one of HWTSTAMP_CLOCK_TYPE_*
+ * @domain	domain number
+ * @header_offset	how much further into the frame it should search for
+ * 			the PTP header. 0 = start at byte 12. Useful when
+ * 			combined with HSR tags.
+ * @delay_mechanism	one of HWTSTAMP_DELAY_MECHANISM_*
  *
  * %SIOCGHWTSTAMP and %SIOCSHWTSTAMP expect a &struct ifreq with a
  * ifr_data pointer to this structure.  For %SIOCSHWTSTAMP, if the
@@ -82,6 +87,9 @@ struct hwtstamp_config {
 	int tx_type;
 	int rx_filter;
 	int clk_type;
+	int domain;
+	int header_offset;
+	int delay_mechanism;
 };
 
 /* possible values for hwtstamp_config->flags */
@@ -190,6 +198,12 @@ enum hwtstamp_clk_types {
 	HWTSTAMP_CLOCK_TYPE_TRANSPARENT_CLOCK,
 	HWTSTAMP_CLOCK_TYPE_ORDINARY_CLOCK,
 	HWTSTAMP_CLOCK_TYPE_BOUNDARY_CLOCK,
+};
+
+enum hwtstamp_delay_mechanism {
+	HWTSTAMP_DELAY_MECHANISM_OFF,
+	HWTSTAMP_DELAY_MECHANISM_E2E,
+	HWTSTAMP_DELAY_MECHANISM_P2P,
 };
 
 /* SCM_TIMESTAMPING_PKTINFO control message */

--- a/port.c
+++ b/port.c
@@ -2280,6 +2280,13 @@ int process_pdelay_req(struct port *p, struct ptp_message *m)
 		return -1;
 	}
 
+	/* Dummy frame for hardware that can only do p2p1step but needs to do
+	 * normal one-step (two-step for P2P). Send a dummy frame to make it
+	 * look like two-step. The time calculations should still be the same.
+	 */
+	if (p->dummy_pdelay_resp_fup)
+		event = TRANS_P2P1STEP;
+
 	if (p->delayMechanism == DM_E2E) {
 		pr_warning("%s: pdelay_req on E2E port", p->log_name);
 		return 0;
@@ -2335,6 +2342,9 @@ int process_pdelay_req(struct port *p, struct ptp_message *m)
 		rsp->header.correction += p->tx_timestamp_offset;
 		rsp->header.correction += p->rx_timestamp_offset;
 		rsp->header.reserved2  = m->header.reserved2;
+	} else if (p->dummy_pdelay_resp_fup) {
+		rsp->header.reserved2  = m->header.reserved2;
+		rsp->header.flagField[0] |= TWO_STEP;
 	} else {
 		rsp->header.flagField[0] |= TWO_STEP;
 		rsp->pdelay_resp.requestReceiptTimestamp =
@@ -2354,7 +2364,7 @@ int process_pdelay_req(struct port *p, struct ptp_message *m)
 	}
 	if (p->timestamping == TS_P2P1STEP) {
 		goto out;
-	} else if (msg_sots_missing(rsp)) {
+	} else if (!p->dummy_pdelay_resp_fup && msg_sots_missing(rsp)) {
 		pr_err("missing timestamp on transmitted peer delay response");
 		err = -1;
 		goto out;
@@ -2376,8 +2386,9 @@ int process_pdelay_req(struct port *p, struct ptp_message *m)
 
 	fup->pdelay_resp_fup.requestingPortIdentity = m->header.sourcePortIdentity;
 
-	fup->pdelay_resp_fup.responseOriginTimestamp =
-		tmv_to_Timestamp(rsp->hwts.ts);
+	if (!p->dummy_pdelay_resp_fup)
+		fup->pdelay_resp_fup.responseOriginTimestamp =
+			tmv_to_Timestamp(rsp->hwts.ts);
 
 	if (msg_unicast(m)) {
 		fup->address = m->address;
@@ -3321,6 +3332,10 @@ struct port *port_open(const char *phc_device,
 	case CLOCK_TYPE_MANAGEMENT:
 		goto err_log_name;
 	}
+
+	if (timestamping == TS_ONESTEP)
+		p->dummy_pdelay_resp_fup =
+			config_get_int(cfg, interface_name(interface), "dummy_pdelay_resp_fup");
 
 	p->phc_index = config_get_int(cfg, interface_name(interface), "phc_index");
 	if (p->phc_index < 0)

--- a/port_private.h
+++ b/port_private.h
@@ -164,6 +164,7 @@ struct port {
 	/* slave event monitoring */
 	struct monitor *slave_event_monitor;
 	bool unicast_state_dirty;
+	int dummy_pdelay_resp_fup;
 };
 
 #define portnum(p) (p->portIdentity.portNumber)

--- a/raw.c
+++ b/raw.c
@@ -341,6 +341,8 @@ static int raw_open(struct transport *t, struct interface *iface,
 	const char *name;
 	char *str;
 	enum clock_type clk_type;
+	int domain, header_offset;
+	enum delay_mechanism dm;
 
 	name = interface_label(iface);
 	str = config_get_string(t->cfg, name, "ptp_dst_mac");
@@ -377,8 +379,12 @@ static int raw_open(struct transport *t, struct interface *iface,
 		goto no_general;
 
 	clk_type = config_get_int(t->cfg, NULL, "hwtstamp_clk_type");
+	domain = config_get_int(t->cfg, NULL, "domainNumber");
+	header_offset = config_get_int(t->cfg, name, "ptp_header_offset");
+	dm = config_get_int(t->cfg, NULL, "delay_mechanism");
 	if (sk_timestamping_init(efd, name, clk_type, ts_type, TRANS_IEEE_802_3,
-				 interface_get_vclock(iface)))
+				 interface_get_vclock(iface), domain,
+				 dm, header_offset))
 		goto no_timestamping;
 
 	if (sk_general_init(gfd))

--- a/sk.c
+++ b/sk.c
@@ -57,7 +57,8 @@ static void init_ifreq(struct ifreq *ifreq, struct hwtstamp_config *cfg,
 }
 
 static int hwts_init(int fd, const char *device, int rx_filter,
-	int rx_filter2, int clk_type, int tx_type)
+	int rx_filter2, int clk_type, int tx_type, int domain,
+	int delay_mechanism, int header_offset)
 {
 	struct ifreq ifreq;
 	struct hwtstamp_config cfg;
@@ -94,6 +95,9 @@ static int hwts_init(int fd, const char *device, int rx_filter,
 		cfg.tx_type   = tx_type;
 		cfg.rx_filter = HWTSTAMP_FILTER_ALL;
 		cfg.clk_type  = clk_type;
+		cfg.domain    = domain;
+		cfg.delay_mechanism = delay_mechanism;
+		cfg.header_offset = header_offset;
 		err = ioctl(fd, SIOCSHWTSTAMP, &ifreq);
 		if (err < 0) {
 			pr_err("ioctl SIOCSHWTSTAMP failed: %m");
@@ -104,6 +108,9 @@ static int hwts_init(int fd, const char *device, int rx_filter,
 		cfg.tx_type   = tx_type;
 		cfg.rx_filter = orig_rx_filter = rx_filter;
 		cfg.clk_type  = clk_type;
+		cfg.domain    = domain;
+		cfg.delay_mechanism = delay_mechanism;
+		cfg.header_offset = header_offset;
 		err = ioctl(fd, SIOCSHWTSTAMP, &ifreq);
 		if (err < 0) {
 			pr_info("driver rejected most general HWTSTAMP filter");
@@ -556,10 +563,11 @@ int sk_set_priority(int fd, int family, uint8_t dscp)
 
 int sk_timestamping_init(int fd, const char *device, int clk_type,
 			 enum timestamp_type type, enum transport_type transport,
-			 int vclock)
+			 int vclock, int domain, enum delay_mechanism dm, int header_offset)
 {
 	int err, filter1, filter2 = 0, flags, tx_type = HWTSTAMP_TX_ON;
 	struct so_timestamping timestamping;
+	enum hwtstamp_delay_mechanism hw_dm;
 
 	switch (type) {
 	case TS_SOFTWARE:
@@ -614,7 +622,15 @@ int sk_timestamping_init(int fd, const char *device, int clk_type,
 		return -1;
 	}
 
-	err = hwts_init(fd, device, filter1, filter2, clk_type, tx_type);
+	if (dm == DM_E2E)
+		hw_dm = HWTSTAMP_DELAY_MECHANISM_E2E;
+	else if (dm == DM_P2P)
+		hw_dm = HWTSTAMP_DELAY_MECHANISM_P2P;
+	else
+		hw_dm = HWTSTAMP_DELAY_MECHANISM_OFF;
+
+	err = hwts_init(fd, device, filter1, filter2, clk_type, tx_type,
+			domain, hw_dm, header_offset);
 	if (err && !(type == TS_SOFTWARE && errno == ENOTSUP))
 		return err;
 

--- a/sk.h
+++ b/sk.h
@@ -23,6 +23,7 @@
 #include <stdbool.h>
 #include "address.h"
 #include "transport.h"
+#include "dm.h"
 
 /**
  * Defines the available Hardware time-stamp setting modes.
@@ -154,11 +155,14 @@ int sk_set_priority(int fd, int family, uint8_t dscp);
  * @param type        The requested flavor of time stamping.
  * @param transport   The type of transport used.
  * @param vclock      Index of the virtual PHC, or -1 for the physical clock.
+ * @param domain      Domain number for offloaded timestamping.
+ * @param delay_mechanism	The delay mechanism used.
+ * @param header_offset		PTP header offset for offloaded timestamping
  * @return            Zero on success, non-zero otherwise.
  */
 int sk_timestamping_init(int fd, const char *device, int clk_type,
 			 enum timestamp_type type, enum transport_type transport,
-			 int vclock);
+			 int vclock, int domain, enum delay_mechanism, int header_offset);
 
 /**
  * Limits the time that RECVMSG(2) will poll while waiting for the tx timestamp

--- a/udp.c
+++ b/udp.c
@@ -158,6 +158,8 @@ static int udp_open(struct transport *t, struct interface *iface,
 	uint8_t event_dscp, general_dscp;
 	int efd, gfd, ttl;
 	enum clock_type clk_type;
+	int domain, header_offset;
+	enum delay_mechanism dm;
 
 	ttl = config_get_int(t->cfg, name, "udp_ttl");
 	udp->mac.len = 0;
@@ -181,8 +183,11 @@ static int udp_open(struct transport *t, struct interface *iface,
 		goto no_general;
 
 	clk_type = config_get_int(t->cfg, NULL, "hwtstamp_clk_type");
+	domain = config_get_int(t->cfg, NULL, "domainNumber");
+	header_offset = config_get_int(t->cfg, name, "ptp_header_offset");
+	dm = config_get_int(t->cfg, NULL, "delay_mechanism");
 	if (sk_timestamping_init(efd, interface_label(iface), clk_type, ts_type, TRANS_UDP_IPV4,
-				 interface_get_vclock(iface)))
+				 interface_get_vclock(iface), domain, dm, header_offset))
 		goto no_timestamping;
 
 	if (sk_general_init(gfd))

--- a/udp6.c
+++ b/udp6.c
@@ -168,6 +168,8 @@ static int udp6_open(struct transport *t, struct interface *iface,
 	uint8_t event_dscp, general_dscp;
 	int efd, gfd, hop_limit;
 	enum clock_type clk_type;
+	int domain, header_offset;
+	enum delay_mechanism dm;
 
 	hop_limit = config_get_int(t->cfg, name, "udp_ttl");
 	udp6->mac.len = 0;
@@ -198,8 +200,12 @@ static int udp6_open(struct transport *t, struct interface *iface,
 		goto no_general;
 
 	clk_type = config_get_int(t->cfg, NULL, "hwtstamp_clk_type");
+	domain = config_get_int(t->cfg, NULL, "domainNumber");
+	header_offset = config_get_int(t->cfg, name, "ptp_header_offset");
+	dm = config_get_int(t->cfg, NULL, "delay_mechanism");
 	if (sk_timestamping_init(efd, interface_label(iface), clk_type, ts_type,
-				 TRANS_UDP_IPV6, interface_get_vclock(iface)))
+				 TRANS_UDP_IPV6, interface_get_vclock(iface),
+				 domain, dm, header_offset))
 		goto no_timestamping;
 
 	if (sk_general_init(gfd))


### PR DESCRIPTION
- Add dummy_pdelay_resp_fup option (see more below)
- Add ptp_header_offset for skipping protocol tags like HSR
- Add domain to hw config as some PHYs need to match on domain for one-step
- Add delay_mechanism to hw config to configure the PHY in the correct mode

Some PHYs can only choose between two-step or full p2p1step. There is no option for normal one-step. In this case we will let it perform p2p1step, and just send a dummy frame with TS and correctionField unmodified. The calculations will still give the same result.

This is the formula used for two-step:
meanLinkDelay = [(t4 − t1) − (responseOriginTimestamp − requestReceiptTimestamp) − correctedPdelayRespCorrectionField − correctionField of Pdelay_Resp_Follow_Up]/2

t1 and t4 are taken as normal. Request and response timestamps will be set to 0, and the residence time is instead updated in the response correctionField (with the use of the reserved2 field) in HW. The correctionField of the pdelay_resp_fup should be whatever the pdelay_req had on ingress, as it would in two-step.