### PR TITLE
HSR/PRP mode for 1-step TC

### DIFF
--- a/bmc.c
+++ b/bmc.c
@@ -140,60 +140,16 @@ static enum port_state hsr_state_decision(struct clock *c, struct port *r,
 	port_best = port_best_foreign(r);
 	pair_best = port_best_foreign(q);
 
-
-	/* TC */
-	if (clock_type(c) == CLOCK_TYPE_E2E || clock_type(c) == CLOCK_TYPE_P2P) {
-		pr_err("CASAN: TC port %s", port_log_name(r));
-		/* IEC62439-3: A.5.4. b) and c). SLAVE */
-		if (compare(port_best, clock_best) == 0 || compare(pair_best, clock_best) == 0) {
-			if (compare(port_best, pair_best) > 0) {
-				pr_err("CASAN %s: PS_SLAVE", port_log_name(r));
-				return PS_SLAVE;
-			} else {
-				pr_err("CASAN %s: PS_PASSIVE_SLAVE", port_log_name(r));
-				return PS_PASSIVE_SLAVE;
-			}
-		}
-
-		int res1 = compare(clock_best, port_best);
-		int res2 = compare(clock_best, pair_best);
-
-		/* The primary Master should have res1 and res2 as
-		* A_BETTER. Redundant Master should have one or both as
-		* A_BETTER_TOPO, in case of one link being broken that
-		* one will be A_BETTER.
-		*/
-		pr_err("CASAN: res1 %d. res2 %d", res1, res2);
-		if (res1 > 0 && res2 > 0) {
-			/* /\* IEC62439-3: A.5.4. a) Active MASTER *\/ */
-			/* if (res1 == A_BETTER && res2 == A_BETTER) { */
-			pr_err("CASAN %s: PS_MASTER 2", port_log_name(r));
-			return PS_MASTER;
-			/* } */
-			/* IEC62439-3: A.5.4. d) Redundant MASTER */
-			/* pr_err("CASAN %s: PS_PASSIVE 1", port_log_name(r)); */
-			/* return PS_PASSIVE; */
-		}
-
-		/* pr_err("HSR BMC state decision failed %s", port_log_name(r)); */
-		pr_err("HSR BMC state decision fallback to FAULTY %s", port_log_name(r));
-		return PS_FAULTY;
-	}
-
-
 	/* IEC62439-3: A.5.4. b) and c). SLAVE */
 	if (compare(port_best, clock_best) == 0 || compare(pair_best, clock_best) == 0) {
 		if (compare(port_best, pair_best) > 0) {
-			pr_err("CASAN %s: PS_SLAVE", port_log_name(r));
 			return PS_SLAVE;
 		} else {
-			pr_err("CASAN %s: PS_PASSIVE_SLAVE", port_log_name(r));
 			return PS_PASSIVE_SLAVE;
 		}
 	}
 
 	if (!port_best && !pair_best) {
-		pr_err("CASAN %s: PS_MASTER 1", port_log_name(r));
 		return PS_MASTER;
 	}
 
@@ -208,17 +164,18 @@ static enum port_state hsr_state_decision(struct clock *c, struct port *r,
 	if (res1 > 0 && res2 > 0) {
 		/* /\* IEC62439-3: A.5.4. a) Active MASTER *\/ */
 		if (res1 == A_BETTER && res2 == A_BETTER) {
-			pr_err("CASAN %s: PS_MASTER 2", port_log_name(r));
 			return PS_MASTER;
 		}
 		/* IEC62439-3: A.5.4. d) Redundant MASTER */
-		pr_err("CASAN %s: PS_PASSIVE 1", port_log_name(r));
-		return PS_PASSIVE;
+		if (clock_type(c) != CLOCK_TYPE_E2E && clock_type(c) != CLOCK_TYPE_P2P) {
+			return PS_PASSIVE;
+		}
 	}
 	/* IEC62439-3: A.5.4. d) Redundant MASTER */
-	if (compare(port_best, pair_best) != 0) {
-		pr_err("CASAN %s: PS_PASSIVE 2", port_log_name(r));
-		return PS_PASSIVE;
+	if (clock_type(c) != CLOCK_TYPE_E2E && clock_type(c) != CLOCK_TYPE_P2P) {
+		if (compare(port_best, pair_best) != 0) {
+			return PS_PASSIVE;
+		}
 	}
 
 	pr_err("HSR BMC state decision failed %s", port_log_name(r));
@@ -250,7 +207,7 @@ enum port_state bmc_state_decision(struct clock *c, struct port *r,
 	if (!port_best && PS_LISTENING == ps)
 		return ps;
 
-	if (clock_is_hsr(c) && port_get_paired(r)) {
+	if ((clock_is_hsr(c) || clock_is_prp(c)) && port_get_paired(r)) {
 		return hsr_state_decision(c, r, compare);
 	}
 

--- a/clock.c
+++ b/clock.c
@@ -32,6 +32,7 @@
 #include "clockcheck.h"
 #include "foreign.h"
 #include "filter.h"
+#include "fsm.h"
 #include "missing.h"
 #include "msg.h"
 #include "phc.h"
@@ -977,6 +978,7 @@ static int forwarding(struct clock *c, struct port *p)
 	case PS_SLAVE:
 	case PS_UNCALIBRATED:
 	case PS_PRE_MASTER:
+	case PS_PASSIVE_SLAVE:
 		return 1;
 	default:
 		break;
@@ -2308,6 +2310,10 @@ static void handle_state_decision_event(struct clock *c)
 			clock_update_slave(c);
 			event = EV_RS_SLAVE;
 			break;
+		case PS_PASSIVE_SLAVE:
+			/* clock_update_slave(c); */
+			event = EV_RS_PSLAVE;
+			break;
 		default:
 			event = EV_FAULT_DETECTED;
 			break;
@@ -2353,4 +2359,14 @@ struct servo *clock_servo(struct clock *c)
 enum servo_state clock_servo_state(struct clock *c)
 {
 	return c->servo_state;
+}
+
+bool clock_is_hsr(struct clock *c)
+{
+	return c->hsr_prp_mode == HSR_PRP_MODE_HSR;
+}
+
+bool clock_is_prp(struct clock *c)
+{
+	return c->hsr_prp_mode == HSR_PRP_MODE_PRP;
 }

--- a/clock.c
+++ b/clock.c
@@ -1997,6 +1997,7 @@ int clock_switch_phc(struct clock *c, int phc_index)
 		return -1;
 	}
 	fadj = clockadj_get_freq(clkid);
+	c->freq = fadj;
 	servo = servo_create(c->config, c->servo_type, -fadj, max_adj, 0);
 	if (!servo) {
 		pr_err("Switching PHC, failed to create clock servo");
@@ -2359,6 +2360,11 @@ struct servo *clock_servo(struct clock *c)
 enum servo_state clock_servo_state(struct clock *c)
 {
 	return c->servo_state;
+}
+
+bool clock_tc_syntonize(struct clock *c)
+{
+	return c->tc_syntonize;
 }
 
 bool clock_is_hsr(struct clock *c)

--- a/clock.h
+++ b/clock.h
@@ -436,4 +436,7 @@ void clock_check_ts(struct clock *c, uint64_t ts);
  */
 double clock_rate_ratio(struct clock *c);
 
+bool clock_is_hsr(struct clock *c);
+bool clock_is_prp(struct clock *c);
+
 #endif

--- a/clock.h
+++ b/clock.h
@@ -436,6 +436,8 @@ void clock_check_ts(struct clock *c, uint64_t ts);
  */
 double clock_rate_ratio(struct clock *c);
 
+bool clock_tc_syntonize(struct clock *c);
+
 bool clock_is_hsr(struct clock *c);
 bool clock_is_prp(struct clock *c);
 

--- a/clock.h
+++ b/clock.h
@@ -43,6 +43,12 @@ enum clock_type {
 	CLOCK_TYPE_MANAGEMENT = 0x0800,
 };
 
+enum hsr_prp_mode {
+	HSR_PRP_MODE_NONE,
+	HSR_PRP_MODE_HSR,
+	HSR_PRP_MODE_PRP,
+};
+
 /**
  * Appends the active time zone TLVs to a given message.
  * @param c          The clock instance.

--- a/config.c
+++ b/config.c
@@ -234,6 +234,13 @@ static struct config_enum bmca_enu[] = {
 	{ NULL, 0 },
 };
 
+static struct config_enum hsr_prp_enu[] = {
+	{ "none", HSR_PRP_MODE_NONE},
+	{ "hsr",  HSR_PRP_MODE_HSR},
+	{ "prp",  HSR_PRP_MODE_PRP},
+	{ NULL, 0 },
+};
+
 struct config_item config_tab[] = {
 	PORT_ITEM_INT("allowedLostResponses", 3, 1, 255),
 	PORT_ITEM_INT("announceReceiptTimeout", 3, 2, UINT8_MAX),
@@ -381,6 +388,9 @@ struct config_item config_tab[] = {
 	PORT_ITEM_INT("dummy_pdelay_resp_fup", 0, 0, 1),
 	PORT_ITEM_INT("ptp_header_offset", 0, 0, INT_MAX),
 	GLOB_ITEM_INT("tc_syntonize", 0, 0, 1),
+	GLOB_ITEM_ENU("hsr_prp_mode", HSR_PRP_MODE_NONE, hsr_prp_enu), 
+	PORT_ITEM_INT("hsr_prp_port_a", 0, 0, 1),
+	PORT_ITEM_INT("hsr_prp_port_b", 0, 0, 1),
 };
 
 static struct unicast_master_table *current_uc_mtab;

--- a/e2e_tc.c
+++ b/e2e_tc.c
@@ -69,6 +69,7 @@ void e2e_dispatch(struct port *p, enum fsm_event event, int mdiff)
 		flush_delay_req(p);
 		/* fall through */
 	case PS_SLAVE:
+	case PS_PASSIVE_SLAVE:
 		port_set_announce_tmo(p);
 		break;
 	};

--- a/e2e_tc.c
+++ b/e2e_tc.c
@@ -72,6 +72,15 @@ void e2e_dispatch(struct port *p, enum fsm_event event, int mdiff)
 		port_set_announce_tmo(p);
 		break;
 	};
+
+	if (clock_tc_syntonize(p->clock) && p->jbod && p->state == PS_UNCALIBRATED && p->phc_index >= 0 ) {
+		if (clock_switch_phc(p->clock, p->phc_index)) {
+			p->last_fault_type = FT_SWITCH_PHC;
+			port_dispatch(p, EV_FAULT_DETECTED, 0);
+			return;
+		}
+		clock_sync_interval(p->clock, p->log_sync_interval);
+	}
 }
 
 enum fsm_event e2e_event(struct port *p, int fd_index)

--- a/fsm.c
+++ b/fsm.c
@@ -231,6 +231,12 @@ enum port_state ptp_fsm(enum port_state state, enum fsm_event event, int mdiff)
 		break;
 	case PS_PASSIVE_SLAVE:
 		switch (event) {
+		case EV_DESIGNATED_DISABLED:
+			next = PS_DISABLED;
+			break;
+		case EV_FAULT_DETECTED:
+			next = PS_FAULTY;
+			break;
 		case EV_RS_MASTER:
 			next = PS_PRE_MASTER;
 			break;

--- a/fsm.c
+++ b/fsm.c
@@ -80,6 +80,9 @@ enum port_state ptp_fsm(enum port_state state, enum fsm_event event, int mdiff)
 		case EV_RS_PASSIVE:
 			next = PS_PASSIVE;
 			break;
+		case EV_RS_PSLAVE:
+			    next = PS_PASSIVE_SLAVE;
+			break;
 		default:
 			break;
 		}
@@ -102,6 +105,9 @@ enum port_state ptp_fsm(enum port_state state, enum fsm_event event, int mdiff)
 		case EV_RS_PASSIVE:
 			next = PS_PASSIVE;
 			break;
+		case EV_RS_PSLAVE:
+			    next = PS_PASSIVE_SLAVE;
+			break;
 		default:
 			break;
 		}
@@ -121,6 +127,9 @@ enum port_state ptp_fsm(enum port_state state, enum fsm_event event, int mdiff)
 			break;
 		case EV_RS_PASSIVE:
 			next = PS_PASSIVE;
+			break;
+		case EV_RS_PSLAVE:
+			    next = PS_PASSIVE_SLAVE;
 			break;
 		default:
 			break;
@@ -178,6 +187,9 @@ enum port_state ptp_fsm(enum port_state state, enum fsm_event event, int mdiff)
 		case EV_RS_PASSIVE:
 			next = PS_PASSIVE;
 			break;
+		case EV_RS_PSLAVE:
+			    next = PS_PASSIVE_SLAVE;
+			break;
 		default:
 			break;
 		}
@@ -210,10 +222,27 @@ enum port_state ptp_fsm(enum port_state state, enum fsm_event event, int mdiff)
 		case EV_RS_PASSIVE:
 			next = PS_PASSIVE;
 			break;
+		case EV_RS_PSLAVE:
+			    next = PS_PASSIVE_SLAVE;
+			break;
 		default:
 			break;
 		}
 		break;
+	case PS_PASSIVE_SLAVE:
+		switch (event) {
+		case EV_RS_MASTER:
+			next = PS_PRE_MASTER;
+			break;
+		case EV_RS_PASSIVE:
+			next = PS_PASSIVE;
+			break;
+		case EV_RS_SLAVE:
+			next = PS_UNCALIBRATED;
+			break;
+		default:
+			break;
+		}
 	}
 
 	return next;

--- a/fsm.h
+++ b/fsm.h
@@ -32,6 +32,7 @@ enum port_state {
 	PS_UNCALIBRATED,
 	PS_SLAVE,
 	PS_GRAND_MASTER, /*non-standard extension*/
+	PS_PASSIVE_SLAVE,
 };
 
 /** Defines the events for the port state machine. */
@@ -53,6 +54,7 @@ enum fsm_event {
 	EV_RS_GRAND_MASTER,
 	EV_RS_SLAVE,
 	EV_RS_PASSIVE,
+	EV_RS_PSLAVE,
 };
 
 enum bmca_select {

--- a/msg.h
+++ b/msg.h
@@ -72,6 +72,10 @@
 #define SIGNAL_NO_CHANGE   -128
 #define SIGNAL_SET_INITIAL 126
 
+#define PRP_LAN_A_BITS (0b10 << 12)
+#define PRP_LAN_B_BITS (0b11 << 12)
+#define PRP_LAN_BITMASK (0b11 << 12)
+
 enum timestamp_type {
 	TS_SOFTWARE,
 	TS_HARDWARE,

--- a/p2p_tc.c
+++ b/p2p_tc.c
@@ -18,6 +18,7 @@
  */
 #include <errno.h>
 
+#include "clock.h"
 #include "ddt.h"
 #include "port.h"
 #include "port_private.h"
@@ -107,6 +108,15 @@ void p2p_dispatch(struct port *p, enum fsm_event event, int mdiff)
 		port_set_announce_tmo(p);
 		break;
 	};
+
+	if (clock_tc_syntonize(p->clock) && p->jbod && p->state == PS_UNCALIBRATED && p->phc_index >= 0 ) {
+		if (clock_switch_phc(p->clock, p->phc_index)) {
+			p->last_fault_type = FT_SWITCH_PHC;
+			port_dispatch(p, EV_FAULT_DETECTED, 0);
+			return;
+		}
+		clock_sync_interval(p->clock, p->log_sync_interval);
+	}
 }
 
 enum fsm_event p2p_event(struct port *p, int fd_index)

--- a/pmc.c
+++ b/pmc.c
@@ -479,7 +479,7 @@ static void pmc_show(struct ptp_message *msg, FILE *fp)
 		break;
 	case MID_PORT_DATA_SET:
 		p = (struct portDS *) mgt->data;
-		if (p->portState > PS_SLAVE) {
+		if (p->portState > PS_SLAVE && p->portState != PS_PASSIVE_SLAVE) {
 			p->portState = 0;
 		}
 		fprintf(fp, "PORT_DATA_SET "
@@ -510,7 +510,7 @@ static void pmc_show(struct ptp_message *msg, FILE *fp)
 		break;
 	case MID_PORT_PROPERTIES_NP:
 		ppn = (struct port_properties_np *) mgt->data;
-		if (ppn->port_state > PS_SLAVE) {
+		if (ppn->port_state > PS_SLAVE && ppn->port_state != PS_PASSIVE_SLAVE) {
 			ppn->port_state = 0;
 		}
 		fprintf(fp, "PORT_PROPERTIES_NP "

--- a/port.c
+++ b/port.c
@@ -2239,6 +2239,7 @@ void process_follow_up(struct port *p, struct ptp_message *m)
 	case PS_MASTER:
 	case PS_GRAND_MASTER:
 	case PS_PASSIVE:
+	case PS_PASSIVE_SLAVE:
 		return;
 	case PS_UNCALIBRATED:
 	case PS_SLAVE:
@@ -2694,6 +2695,7 @@ static void port_e2e_transition(struct port *p, enum port_state next)
 		port_set_sync_tx_tmo(p);
 		break;
 	case PS_PASSIVE:
+	case PS_PASSIVE_SLAVE:
 		port_set_announce_tmo(p);
 		break;
 	case PS_UNCALIBRATED:

--- a/port.c
+++ b/port.c
@@ -2560,6 +2560,7 @@ void process_sync(struct port *p, struct ptp_message *m)
 	case PS_MASTER:
 	case PS_GRAND_MASTER:
 	case PS_PASSIVE:
+	case PS_PASSIVE_SLAVE:
 		return;
 	case PS_UNCALIBRATED:
 	case PS_SLAVE:

--- a/port.c
+++ b/port.c
@@ -3495,6 +3495,10 @@ struct port *port_open(const char *phc_device,
 			goto err_tsproc;
 		}
 	}
+
+	p->hsr_prp_port_a = config_get_int(cfg, p->name, "hsr_prp_port_a");
+	p->hsr_prp_port_b = config_get_int(cfg, p->name, "hsr_prp_port_b");
+
 	return p;
 
 err_tsproc:
@@ -3525,6 +3529,7 @@ enum delay_mechanism port_delay_mechanism(struct port *port)
 int port_state_update(struct port *p, enum fsm_event event, int mdiff)
 {
 	enum port_state next = p->state_machine(p->state, event, mdiff);
+
 
 	if (PS_FAULTY == next) {
 		struct fault_interval i;
@@ -3577,4 +3582,25 @@ void port_update_unicast_state(struct port *p)
 		unicast_client_state_changed(p);
 		p->unicast_state_dirty = false;
 	}
+}
+
+bool port_hsr_prp_a(struct port *p)
+{
+	return p->hsr_prp_port_a;
+}
+
+bool port_hsr_prp_b(struct port *p)
+{
+	return p->hsr_prp_port_b;
+}
+
+void port_set_paired(struct port *p, struct port *q)
+{
+	p->paired_port = q;
+	q->paired_port = p;
+}
+
+struct port *port_get_paired(struct port *p)
+{
+	return p->paired_port;
 }

--- a/port.h
+++ b/port.h
@@ -364,4 +364,9 @@ void tc_cleanup(void);
  */
 void port_update_unicast_state(struct port *p);
 
+bool port_hsr_prp_a(struct port *p);
+bool port_hsr_prp_b(struct port *p);
+void port_set_paired(struct port *p, struct port *partner);
+struct port *port_get_paired(struct port *p);
+
 #endif

--- a/port_private.h
+++ b/port_private.h
@@ -165,6 +165,9 @@ struct port {
 	struct monitor *slave_event_monitor;
 	bool unicast_state_dirty;
 	int dummy_pdelay_resp_fup;
+        bool hsr_prp_port_a;
+        bool hsr_prp_port_b;
+	struct port *paired_port;
 };
 
 #define portnum(p) (p->portIdentity.portNumber)

--- a/port_signaling.c
+++ b/port_signaling.c
@@ -147,6 +147,7 @@ int process_signaling(struct port *p, struct ptp_message *m)
 	case PS_PASSIVE:
 	case PS_UNCALIBRATED:
 	case PS_SLAVE:
+	case PS_PASSIVE_SLAVE:
 		break;
 	}
 

--- a/tc.h
+++ b/tc.h
@@ -109,4 +109,6 @@ int tc_ignore(struct port *q, struct ptp_message *m);
  */
 void tc_prune(struct port *q);
 
+int tc_blocked(struct port *q, struct port *p, struct ptp_message *m);
+
 #endif

--- a/ts2phc.c
+++ b/ts2phc.c
@@ -342,6 +342,7 @@ static void ts2phc_reconfigure(struct ts2phc_private *priv)
 		case PS_PRE_MASTER:
 		case PS_MASTER:
 		case PS_PASSIVE:
+		case PS_PASSIVE_SLAVE:
 			if (!c->is_target) {
 				pr_info("selecting %s for synchronization",
 					c->name);

--- a/ts2phc.h
+++ b/ts2phc.h
@@ -12,6 +12,7 @@
 #include <time.h>
 #include <gpiod.h>
 
+#include "clock.h"
 #include "pmc_agent.h"
 #include "servo.h"
 #include "ts2phc_pps_source.h"
@@ -61,6 +62,7 @@ struct ts2phc_private {
 	int use_gpio;
 	int gpio_polarity;
 	int last_edge_rising;
+	enum clock_type clock_type;
 	LIST_HEAD(port_head, ts2phc_port) ports;
 	LIST_HEAD(clock_head, ts2phc_clock) clocks;
 };

--- a/unicast_service.c
+++ b/unicast_service.c
@@ -532,6 +532,7 @@ int unicast_service_timer(struct port *p)
 	case PS_PASSIVE:
 	case PS_UNCALIBRATED:
 	case PS_SLAVE:
+	case PS_PASSIVE_SLAVE:
 		break;
 	case PS_MASTER:
 	case PS_GRAND_MASTER:

--- a/util.c
+++ b/util.c
@@ -49,6 +49,7 @@ const char *ps_str[] = {
 	"UNCALIBRATED",
 	"SLAVE",
 	"GRAND_MASTER",
+	"PASSIVE_SLAVE",
 };
 
 const char *ev_str[] = {
@@ -69,6 +70,7 @@ const char *ev_str[] = {
 	"RS_GRAND_MASTER",
 	"RS_SLAVE",
 	"RS_PASSIVE",
+	"RS_PSLAVE",
 };
 
 const char *ts_str(enum timestamp_type ts)


### PR DESCRIPTION
Implements HSR/PRP modes for offloaded duplication. Prioritize sending on port A when possible, and always use its port identity. 

Expectations from HW:
- Peer delays are not duplicated (they are link-local)
- DelayResp are not duplicated (they are forwarded separately based on origin LAN of request)
- HW forwards messages within the HSR ring and performs residence time correction

I can rebase this on v4.2 later.