### PR TITLE
Add startup_wait and fix ts2phc state transitions

### DIFF
--- a/clock.c
+++ b/clock.c
@@ -1731,10 +1731,9 @@ static void clock_forward_mgmt_msg(struct clock *c, struct port *p, struct ptp_m
 		}
 		if (clock_do_forward_mgmt(c, p, c->uds_rw_port, msg, &msg_ready))
 			pr_debug("uds port: management forward failed");
-		if (msg_ready) {
+		if (msg_ready)
 			msg_post_recv(msg, pdulen);
-			msg->management.boundaryHops++;
-		}
+		msg->management.boundaryHops++;
 	}
 }
 

--- a/config.c
+++ b/config.c
@@ -394,6 +394,7 @@ struct config_item config_tab[] = {
 	GLOB_ITEM_INT("setup_tc_rules", 0, 0, 1),
 	GLOB_ITEM_INT("set_process_priority", 0, 0, 1),
 	GLOB_ITEM_INT("tc_hw_fwd", 0, 0, 1),
+	GLOB_ITEM_INT("startup_wait", 0, 0, 60),
 };
 
 static struct unicast_master_table *current_uc_mtab;

--- a/ptp4l.c
+++ b/ptp4l.c
@@ -77,6 +77,7 @@ int main(int argc, char *argv[])
 	struct clock *clock = NULL;
 	struct option *opts;
 	struct config *cfg;
+	int startup_wait;
 
 	if (handle_term_signals())
 		return -1;
@@ -190,6 +191,12 @@ int main(int argc, char *argv[])
 
 		/* Set ptp kworker priority */
 		system("pgrep -f \"ptp[0-9]+$\" | xargs -I {} chrt -f -p 75 {}");
+	}
+
+	startup_wait = config_get_int(cfg, NULL, "startup_wait");
+	if (startup_wait) {
+		pr_notice("delaying startup by %d seconds", startup_wait);
+		sleep(startup_wait);
 	}
 
 	print_set_progname(progname);

--- a/ts2phc.c
+++ b/ts2phc.c
@@ -80,8 +80,16 @@ static enum port_state ts2phc_clock_compute_state(struct ts2phc_private *priv,
 		 * after that, PS_MASTER is third, PS_PRE_MASTER fourth and
 		 * all of that overrides PS_DISABLED, which corresponds
 		 * nicely with the numerical values */
-		if (p->state > state)
+		if (p->state > state) {
+			/* PASSIVE_SLAVE is numerically highest. This
+			 * check is to ensure it's prioritized only
+			 * above DISABLED.
+			 */
+			if (p->state == PS_PASSIVE_SLAVE && state != PS_DISABLED)
+				continue;
+
 			state = p->state;
+		}
 	}
 	return state;
 }

--- a/ts2phc.c
+++ b/ts2phc.c
@@ -604,6 +604,7 @@ int main(int argc, char *argv[])
 	struct interface *iface;
 	int gpio_sleep_us = 0;
 	struct option *opts;
+	int startup_wait;
 	int autocfg = 0;
 
 	handle_term_signals();
@@ -698,6 +699,12 @@ int main(int argc, char *argv[])
 		struct sched_param schedp = { .sched_priority = 49 };
 		if (sched_setscheduler(0, SCHED_FIFO, &schedp))
 			pr_err("Failed raising ts2phc priority: %m");
+	}
+
+	startup_wait = config_get_int(cfg, NULL, "startup_wait");
+	if (startup_wait) {
+		pr_notice("delaying startup by %d seconds", startup_wait);
+		sleep(startup_wait);
 	}
 
 	print_set_progname(progname);

--- a/util.c
+++ b/util.c
@@ -215,6 +215,7 @@ enum port_state port_state_normalize(enum port_state state)
 	case PS_SLAVE:
 	case PS_PRE_MASTER:
 	case PS_UNCALIBRATED:
+	case PS_PASSIVE_SLAVE:
 		return state;
 	default:
 		return PS_DISABLED;


### PR DESCRIPTION
Should `ts2phc` also have `startup_wait`? Just remembered this after creating the PR.