### PR TITLE
pmc: Handle --ptp_minor_version argument

### DIFF
--- a/pmc.c
+++ b/pmc.c
@@ -976,6 +976,9 @@ int main(int argc, char *argv[])
 	transport_specific = config_get_int(cfg, NULL, "transportSpecific") << 4;
 	domain_number = config_get_int(cfg, NULL, "domainNumber");
 
+	ptp_hdr_ver = config_get_int(cfg, NULL, "ptp_minor_version");
+	ptp_hdr_ver = (ptp_hdr_ver << 4) | PTP_MAJOR_VERSION;
+
 	if (!iface_name) {
 		if (transport_type == TRANS_UDS) {
 			snprintf(uds_local, sizeof(uds_local),

--- a/pmc_common.c
+++ b/pmc_common.c
@@ -23,6 +23,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "msg.h"
 #include "notification.h"
 #include "print.h"
 #include "tlv.h"
@@ -569,7 +570,7 @@ static struct ptp_message *pmc_message(struct pmc *pmc, uint8_t action)
 	msg->hwts.type = TS_SOFTWARE;
 
 	msg->header.tsmt               = MANAGEMENT | pmc->transport_specific;
-	msg->header.ver                = PTP_VERSION;
+	msg->header.ver                = ptp_hdr_ver;
 	msg->header.messageLength      = pdulen;
 	msg->header.domainNumber       = pmc->domain_number;
 	msg->header.sourcePortIdentity = pmc->port_identity;


### PR DESCRIPTION
So we can set minor version for pmc requests.

ptp_hdr_ver is a global variable. This was already set in ptp4l but was missing in pmc.